### PR TITLE
fix logo

### DIFF
--- a/provider/cmd/pulumi-resource-slack/schema.json
+++ b/provider/cmd/pulumi-resource-slack/schema.json
@@ -11,7 +11,7 @@
     "license": "Apache-2.0",
     "attribution": "This Pulumi package is based on the [`slack` Terraform Provider](https://github.com/pablovarela/terraform-provider-slack).",
     "repository": "https://github.com/pulumi/pulumi-slack",
-    "logoUrl": "https://cdn.bfldr.com/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.svg",
+    "logoUrl": "",
     "publisher": "Pulumi",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"


### PR DESCRIPTION
this is removing the url so it will use the correct logo that's in pulumi-hugo
let me know if yall would rather host the file in this repo